### PR TITLE
bugfix: check arr index on number instead of boolean

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,12 +19,12 @@ module.exports = {
     }
     
 
-    if (findOneUser) {
+    if (findOneUser >= 0) {
       initializeRoute(userRoutes, findOneUser);
       userRoutes[findOneUser].config.middlewares.push(isUserOwnerMiddleware);
     }
 
-    if (findUpdateUser) {
+    if (findUpdateUser >= 0) {
       initializeRoute(userRoutes, findUpdateUser);
       userRoutes[findUpdateUser].config.middlewares.push(isUserOwnerMiddleware);
     }


### PR DESCRIPTION
The result of findIndex() func should be checked on index number instead of a boolean, because findIndex() func returns -1 in case of a failure, which casts to true. So we should check if value is greater than or equal to zero